### PR TITLE
Only log in verbose mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = {
         var promises = [];
         var jsFilePaths = fetchFilePaths(distFiles, publicUrl, 'js');
         var mapFilePaths = fetchFilePaths(distFiles, distDir, 'map');
-        log('Uploading sourcemaps to bugsnag');
+        log('Uploading sourcemaps to bugsnag', { verbose: true });
 
         for (var i = 0; i < mapFilePaths.length; i++) {
           var mapFilePath = mapFilePaths[i];
@@ -69,12 +69,12 @@ module.exports = {
         }
         return RSVP.all(promises)
           .then(function() {
-            log('Finished uploading sourcemaps');
+            log('Finished uploading sourcemaps', { verbose: true });
           });
       },
 
       didUpload() {
-        this.log('Deleting sourcemaps');
+        this.log('Deleting sourcemaps', { verbose: true });
         var deleteSourcemaps = this.readConfig('deleteSourcemaps');
         if (deleteSourcemaps) {
           var distDir = this.readConfig('distDir');


### PR DESCRIPTION
Thanks for your work on this plugin! One thing we've noticed using it is that it's a little noisier than other deploy plugins typically are — e.g. `ember-cli-deploy-s3` [only emits messages in verbose mode](https://github.com/ember-cli-deploy/ember-cli-deploy-s3/blob/master/index.js#L95).

This PR adds `verbose: true` to the log messages here so that they're only shown if the user asks for it :)