### PR TITLE
Allow users to opt out of `appVersion`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Set in [`config/deploy.js`](http://ember-cli-deploy.com/docs/v1.0.x/configuratio
 | `distFiles`     | array of strings | No      | `context.distFiles` | The array of built project files. This option should be relative to `distDir`. By default, this option will use the `distFiles` property of the [deployment context](http://ember-cli-deploy.com/docs/v0.5.x/deployment-context/). |
 | `overwrite`     | string | No      | `true` | If set to `false`, existing sourcemaps for the same version of your app will not be overwritten. Options are `true` or `false`. |
 | `publicUrl`  | string | Yes      | `<none>` | The fully qualified domain name for your application e.g., `https://app.fancy-app.com` |
+| `includeAppVersion` | boolean | No | `true` | Whether to tag the uploaded sourcemaps as belonging to a particular app version. |
 
 #### Related plugin options
 

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ module.exports = {
             return process.env.SOURCE_VERSION || '';
           }
         },
+        includeAppVersion: true,
         deleteSourcemaps: true,
         overwrite: 'true',
       },
@@ -43,6 +44,7 @@ module.exports = {
         var distFiles = this.readConfig('distFiles');
         var publicUrl = this.readConfig('publicUrl');
         var overwrite = this.readConfig('overwrite');
+        var includeAppVersion = this.readConfig('includeAppVersion');
         var promises = [];
         var jsFilePaths = fetchFilePaths(distFiles, publicUrl, 'js');
         var mapFilePaths = fetchFilePaths(distFiles, distDir, 'map');
@@ -57,7 +59,7 @@ module.exports = {
             minifiedUrl: jsFilePath,
             sourceMap: fs.createReadStream(mapFilePath)
           };
-          if (revisionKey) {
+          if (revisionKey && includeAppVersion) {
             formData.appVersion = revisionKey;
           }
           var promise = request({


### PR DESCRIPTION
By default, `ember-cli-deploy-revision-data` generates the revision key based on a hash of `index.html`, which creates a chicken-and-egg problem for getting the current revision key _into_ the build. Obviously this can be worked around by choosing a different revision data `type`, but we've just never bothered to set an `appVersion` on our Bugsnag client, as we deploy often enough that versions aren't particularly meaningful anyway.

On the Bugsnag side, though, it seems when you include an `appVersion` with an uploaded source map, it gets ignored for errors reported without one. This PR allows users to opt out of including it.