### PR TITLE
Handle gzipped source maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Set by other Ember CLI Deploy plugins:
 | ---------- | ------------- | -------- | ----------- | ------ |
 | `distDir`     | string | `tmp/deploy-dist` | The path to your app's distribution directory. | [`ember-cli-build`](https://github.com/zapnito/ember-cli-deploy-build) |
 | `revisionKey`  | string | `<none>` | The unique identifier of a build based on its git tag. | [`ember-cli-deploy-revision-data`](https://github.com/zapnito/ember-cli-deploy-revision-data) |
+| `gzippedFiles` | array | `<none>` | A list of files that have been gzipped in the build. | [`ember-cli-deploy-gzip`](https://github.com/ember-cli-deploy/ember-cli-deploy-gzip) |
 
 ### Deploying to Heroku
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,9 @@
 
 var RSVP = require('rsvp');
 var fs = require('fs');
+var path = require('path');
 var request = require('request-promise');
+var zlib = require('zlib');
 
 var BasePlugin = require('ember-cli-deploy-plugin');
 
@@ -21,6 +23,9 @@ module.exports = {
         },
         distFiles: function(context) {
           return context.distFiles;
+        },
+        gzippedFiles: function(context) {
+          return context.gzippedFiles || [];
         },
         revisionKey: function(context) {
           if (context.revisionData) {
@@ -55,7 +60,7 @@ module.exports = {
             apiKey: apiKey,
             overwrite: overwrite,
             minifiedUrl: jsFilePath,
-            sourceMap: fs.createReadStream(mapFilePath)
+            sourceMap: this._readSourceMap(mapFilePath)
           };
           if (revisionKey) {
             formData.appVersion = revisionKey;
@@ -95,6 +100,22 @@ module.exports = {
           return RSVP.all(promises);
         }
       },
+
+      _readSourceMap(mapFilePath) {
+        var relativeMapFilePath = mapFilePath.replace(this.readConfig('distDir') + '/', '');
+        if (this.readConfig('gzippedFiles').indexOf(relativeMapFilePath) !== -1) {
+          // When the source map is gzipped, we need to eagerly load it into a buffer
+          // so that the actual content length is known.
+          return {
+            value: zlib.unzipSync(fs.readFileSync(mapFilePath)),
+            options: {
+              filename: path.basename(mapFilePath),
+            }
+          };
+        } else {
+          return fs.createReadStream(mapFilePath);
+        }
+      }
     });
 
     return new DeployPlugin();


### PR DESCRIPTION
Aaaand one more 🙂 

We use `ember-cli-deploy-gzip` to gzip our assets (including sourcemaps) before upload, and it looks like Bugsnag will happily accept a gzipped source map and then have no clue what to actually do with it. This change adds logic to check the `gzippedFiles` array, if present, to see if maps need to be decompressed before uploading.